### PR TITLE
Fixed Dependency Vulnerabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "nodehaystack",
+  "version": "2.0.4",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nodehaystack",
+      "version": "2.0.4",
+      "license": "AFL-3.0",
+      "dependencies": {
+        "moment-timezone": "^0.5.38"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.38",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.38.tgz",
+      "integrity": "sha512-nMIrzGah4+oYZPflDvLZUgoVUO4fvAqHstvG3xAUnMolWncuAiLDWNnJZj6EwJGMGfb1ZcuTFE6GI3hNOVWI/Q==",
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    }
+  },
+  "dependencies": {
+    "moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+    },
+    "moment-timezone": {
+      "version": "0.5.38",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.38.tgz",
+      "integrity": "sha512-nMIrzGah4+oYZPflDvLZUgoVUO4fvAqHstvG3xAUnMolWncuAiLDWNnJZj6EwJGMGfb1ZcuTFE6GI3hNOVWI/Q==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,12 +20,6 @@
     "haystack"
   ],
   "dependencies": {
-    "moment-timezone": "^0.3.0"
-  },
-  "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-jsdoc": "^0.5.8",
-    "ink-docstrap": "^0.5.2",
-    "jsdoc": "^3.3.0-beta3"
+    "moment-timezone": "^0.5.38"
   }
 }


### PR DESCRIPTION
This PR removes unused devDependencies, upgrades `moment-timezone`, and fixes the version of `moment`:

## Before
`21 vulnerabilities (1 low, 5 moderate, 7 high, 8 critical)`

## After
`found 0 vulnerabilities`